### PR TITLE
stevedore < 0.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     install_requires = [
         "colorama>=0.2.5",
         "PyYAML>=3.10",
-        "stevedore >= 0.9.1",
+        "stevedore >= 0.9.1, < 0.14",
         "futures >= 2.1.4",
     ],
     extras_require = {


### PR DESCRIPTION
I leave it up to you whether you merge this, or update plugin.py to use stevedore 0.14
