### PR TITLE
A1400cameradevice

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'spreadsplug.devices': [
             "chdkcamera=spreadsplug.dev.chdkcamera:CHDKCameraDevice",
             "a2200=spreadsplug.dev.chdkcamera:CanonA2200CameraDevice",
-            "a1400=spreadsplug.dev.chdkcamera:CanonA1400CameraDevice",
+            "a1400=spreadsplug.dev.chdkcamera:CHDKCameraDevice",
         ],
         'spreadsplug.hooks': [
             "autorotate     =spreadsplug.autorotate:AutoRotatePlugin",

--- a/spreadsplug/dev/chdkcamera.py
+++ b/spreadsplug/dev/chdkcamera.py
@@ -369,29 +369,3 @@ class CanonA2200CameraDevice(CHDKCameraDevice):
                               "do click(\"zoom_out\") end".format(level+1),
                               wait=True)
 
-class CanonA1400CameraDevice(CHDKCameraDevice):
-    """ Canon A1400 driver.
-
-        Works around some quirks of this camera.
-
-    """
-    def __init__(self, config, device):
-        print "Instantiating device..."
-        super(CanonA1400CameraDevice, self).__init__(config, device)
-        if self.target_page is not None:
-            self.logger = logging.getLogger(
-                'CanonA1400CameraDevice[{0}]'.format(self.target_page))
-        else:
-            self.logger = logging.getLogger('CanonA1400CameraDevice')
-
-    @classmethod
-    def yield_devices(cls, config):
-        """ Search for usable devices, yield one at a time
-
-        """
-        for dev in usb.core.find(find_all=True):
-            is_match = (hex(dev.idVendor) == "0x4a9"
-                        and hex(dev.idProduct) == "0x3264")
-            if is_match:
-                yield cls(config, dev)
-


### PR DESCRIPTION
I encountered a strange race condition with set_zoom on (only one of?) my a1400s. This setting wait=True fixes, rolled up a CameraDevice class to hold this.

The error I was seeing before implementing this:

```
ChdkCamera[right]: Calling chdkptp with arguments: [u'/usr/local/lib/chdkptp/chdkptp', '-c-d=033 -b=001', '-eset cli_verbose=2', '-elua set_zoom(3)']
ChdkCamera[left]: Calling chdkptp with arguments: [u'/usr/local/lib/chdkptp/chdkptp', '-c-d=034 -b=001', '-eset cli_verbose=2', '-elua set_zoom(3)']
ChdkCamera[right]: Calling chdkptp with arguments: [u'/usr/local/lib/chdkptp/chdkptp', '-c-d=033 -b=001', '-eset cli_verbose=2', '-eluar while(get_flash_mode()<2) do click("right") end']
ChdkCamera[left]: Call returned:
['connected: Canon PowerShot A1400, max packet size 512']
ChdkCamera[left]: Calling chdkptp with arguments: [u'/usr/local/lib/chdkptp/chdkptp', '-c-d=034 -b=001', '-eset cli_verbose=2', '-eluar while(get_flash_mode()<2) do click("right") end']
ChdkCamera[right]: Call returned:
['ERROR: a script is already running', 'connected: Canon PowerShot A1400, max packet size 512']
ChdkCamera[left]: Call returned:
['connected: Canon PowerShot A1400, max packet size 512']
ChdkCamera[left]: Calling chdkptp with arguments: [u'/usr/local/lib/chdkptp/chdkptp', '-c-d=034 -b=001', '-eset cli_verbose=2', '-eluar set_nd_filter(2)']
ChdkCamera[left]: Call returned:
['connected: Canon PowerShot A1400, max packet size 512']
ChdkCamera[left]: Calling chdkptp with arguments: [u'/usr/local/lib/chdkptp/chdkptp', '-c-d=034 -b=001', '-eset cli_verbose=2', '-eluar set_aflock(0)']
ChdkCamera[left]: Call returned:
['connected: Canon PowerShot A1400, max packet size 512']
spreads encountered an error:
Traceback (most recent call last):
  File "/usr/local/bin/spread", line 39, in <module>
    cli.main()
  File "/usr/local/lib/python2.7/dist-packages/spreads/cli.py", line 446, in main
    args.subcommand(config)
  File "/usr/local/lib/python2.7/dist-packages/spreads/cli.py", line 254, in capture
    workflow.prepare_capture()
  File "/usr/local/lib/python2.7/dist-packages/spreads/workflow.py", line 163, in prepare_capture
    check_futures_exceptions(futures)
  File "/usr/local/lib/python2.7/dist-packages/spreads/util.py", line 63, in check_futures_exceptions
    raise exc
CHDKPTPException: ERROR: a script is already running
```
