### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,11 +82,11 @@ Documentation
 -------------
 More documentation is available on readthedocs_
 
-.. _adding support for new devices: http://spreads.readthedocs.org/en/latest/extending.html#adding-support-for-new-devices
-.. _plugin hooks: http://spreads.readthedocs.org/en/latest/api.html#spreads-plugin
-.. _implement your own custom sub-commands: http://spreads.readthedocs.org/en/latest/extending.html#adding-new-commands
+.. _adding support for new devices: https://spreads.readthedocs.io/en/latest/developers.html#adding-support-for-new-devices
+.. _plugin hooks: https://spreads.readthedocs.io/en/latest/api.html#spreads-plugin
+.. _implement your own custom sub-commands: https://spreads.readthedocs.io/en/latest/developers.html#adding-new-commands
 .. _ppmunwarp: http://diybookscanner.org/forum/viewtopic.php?f=19&t=2589&p=14281#p14281
-.. _readthedocs: http://spreads.readthedocs.org
+.. _readthedocs: https://spreads.readthedocs.io
 .. _pip: http://www.pip-installer.org
 .. _ScanTailor-enhanced: http://sourceforge.net/p/scantailor/code/ci/enhanced/tree/
 .. _pdfbeads: http://rubygems.org/gems/pdfbeads

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version=spreads.__version__,
     author="Johannes Baiter",
     author_email="johannes.baiter@gmail.com",
-    url="http://spreads.readthedocs.org",
+    url="https://spreads.readthedocs.io",
     description="Book digitization workflow suite",
     long_description=description_long,
     license="GNU AGPLv3",


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
